### PR TITLE
Add menu and alignment to blog page

### DIFF
--- a/blog/app.js
+++ b/blog/app.js
@@ -1,10 +1,18 @@
 const blogPosts = [
     {
-    title: "Sample Blog Post Name",
-    date: "01-01-2025",
-    excerpt: "Sample blog post description.",
-    link: "./sample_blog_post/",
-    category: "Blog Post Category"},
+        title: "Building Agentic AI Systems",
+        date: "21-05-2025",
+        excerpt: "Understanding how autonomous components work together.",
+        link: "./blog_post_one/",
+        category: "AI Insights"
+    },
+    {
+        title: "Scaling Deep Learning Infrastructure",
+        date: "22-05-2025",
+        excerpt: "Lessons from production deployments of large models.",
+        link: "./blog_post_two/",
+        category: "AI Insights"
+    },
 ];
 
 const POSTS_PER_PAGE = 5;

--- a/blog/blog_post_one/index.html
+++ b/blog/blog_post_one/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ritchie@blog ~ agentic_ai$</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../../css/styles.css" />
+</head>
+<body>
+  <div class="container">
+    <div id="menu"></div>
+
+    <div class="bash-block">
+      <div class="bash-line">
+        <span class="prompt">ritchie@blog</span>:<span class="command">~/blog/blog_post_one</span>$ cat post.md
+      </div>
+      <div class="bash-output output-text">
+        <p>The first step to building agentic AI systems is understanding how autonomous components interact.</p>
+        <p>This sample post walks through the core principles behind effective agents.</p>
+      </div>
+    </div>
+
+    <div class="bash-line">
+      <span class="prompt">ritchie@blog</span>:<span class="command">~/blog/blog_post_one</span>$ <span class="cursor">|</span>
+    </div>
+  </div>
+
+  <script src="../../js/menu.js"></script>
+</body>
+</html>

--- a/blog/blog_post_two/index.html
+++ b/blog/blog_post_two/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ritchie@blog ~ scaling_dl$</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../../css/styles.css" />
+</head>
+<body>
+  <div class="container">
+    <div id="menu"></div>
+
+    <div class="bash-block">
+      <div class="bash-line">
+        <span class="prompt">ritchie@blog</span>:<span class="command">~/blog/blog_post_two</span>$ cat post.md
+      </div>
+      <div class="bash-output output-text">
+        <p>Deploying deep learning models at scale requires a balance of software engineering and research insight.</p>
+        <p>This second sample post outlines lessons from real-world AI deployments.</p>
+      </div>
+    </div>
+
+    <div class="bash-line">
+      <span class="prompt">ritchie@blog</span>:<span class="command">~/blog/blog_post_two</span>$ <span class="cursor">|</span>
+    </div>
+  </div>
+
+  <script src="../../js/menu.js"></script>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,9 +10,9 @@
   <link rel="stylesheet" href="../css/styles.css" />
 </head>
 
-<body class="bg-[#101216] text-gray-200 font-mono">
-
-  <main class="max-w-4xl mx-auto px-4 py-8">
+<body>
+  <div class="container">
+    <div id="menu"></div>
 
     <div class="bash-line">
       <span class="prompt">ritchie@blog</span>:<span class="command">~/blog</span>$ ls posts/
@@ -28,8 +28,9 @@
       <span class="prompt">ritchie@blog</span>:<span class="command">~/blog</span>$ <span class="cursor">|</span>
     </div>
 
-  </main>
+  </div>
 
+  <script src="../js/menu.js"></script>
   <script src="./app.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- include the common menu on the blog page
- wrap blog layout with the same container used on other pages
- add two sample blog posts with the same theme
- update the blog listing to link to those posts

## Testing
- `bash test_local.sh` *(failed due to manual interrupt)*